### PR TITLE
Add error-checking to getObjectAsByteString

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "stream-s3-wrapper"
 
-version := "2.8.0"
+version := "2.8.1"
 
 scalaVersion := "2.12.2"
 crossScalaVersions := Seq("2.11.8", "2.12.2")


### PR DESCRIPTION
We want to use this in sqs-handler (and perhaps elsewhere). The method
should automatically check the response code of the returned HTTP
response and only return a successful future if it's a successful
response code.