### PR TITLE
Add getObjectAsEntity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "stream-s3-wrapper"
 
-version := "2.8.2"
+version := "2.8.3"
 
 scalaVersion := "2.12.2"
 crossScalaVersions := Seq("2.11.8", "2.12.2")


### PR DESCRIPTION
getObjectAsEntity downloads an object from s3 without unwrapping it from
the Akka ResponseEntity