### PR TITLE
Make signed url header URL-safe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "stream-s3-wrapper"
 
-version := "2.8.3"
+version := "2.8.4"
 
 scalaVersion := "2.12.2"
 crossScalaVersions := Seq("2.11.8", "2.12.2")

--- a/src/main/scala/io/dronekit/cloud/AWSWrapper.scala
+++ b/src/main/scala/io/dronekit/cloud/AWSWrapper.scala
@@ -173,7 +173,10 @@ class AWSWrapper(S3Client: AmazonS3Client = S3.client)(implicit ec: ExecutionCon
     if (filename.isDefined || contentType.isDefined) {
       val request: GeneratePresignedUrlRequest = new GeneratePresignedUrlRequest(s3url.bucket, s3url.key, HttpMethod.GET)
       val headerOverrides: ResponseHeaderOverrides = new ResponseHeaderOverrides()
-      filename.foreach { name => headerOverrides.setContentDisposition(s"attachment; filename=$name") }
+      filename.foreach { name =>
+        val safeName = java.net.URLEncoder.encode(name, "US-ASCII")
+        headerOverrides.setContentDisposition(s"attachment; filename=${safeName}")
+      }
       contentType.foreach { ct => headerOverrides.setContentType(ct) }
       request.withResponseHeaders(headerOverrides).withExpiration(Date.from(expiry.toInstant))
       S3Client.generatePresignedUrl(request).toString


### PR DESCRIPTION
We pass the filename as a part of the content-disposition header passed
to the S3 signed url generation code, so it needs to be escaped to avoid
unsafe characters showing up. Should fix API-244.